### PR TITLE
Fixed HashIndex bug

### DIFF
--- a/src/test/java/org/fusesource/hawtdb/internal/index/HashIndexTest.java
+++ b/src/test/java/org/fusesource/hawtdb/internal/index/HashIndexTest.java
@@ -33,16 +33,13 @@ public class HashIndexTest extends IndexTestSupport {
         HashIndexFactory<String,Long> factory = new HashIndexFactory<String,Long>();
         factory.setKeyCodec(StringCodec.INSTANCE);
         factory.setValueCodec(LongCodec.INSTANCE);
+        factory.setBucketCapacity(1);
+        factory.setMinimumBucketCapacity(1);
+        factory.setMaximumBucketCapacity(1);
         if( page==-1 ) {
             return factory.create(tx);
         } else {
             return factory.open(tx, page);
         }
-    }
-
-
-    @Override
-    public void testRandomRemove() throws Exception {
-        // TODO: look into why this test is failing.  
     }
 }

--- a/src/test/java/org/fusesource/hawtdb/internal/index/IndexTestSupport.java
+++ b/src/test/java/org/fusesource/hawtdb/internal/index/IndexTestSupport.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.*;
 import java.io.File;
 import java.io.IOException;
 import java.util.Random;
+import org.fusesource.hawtbuf.Buffer;
 
 import org.fusesource.hawtdb.api.TxPageFile;
 import org.fusesource.hawtdb.api.TxPageFileFactory;
@@ -85,6 +86,15 @@ public abstract class IndexTestSupport {
         int page = index.getIndexLocation();
         tx.commit();
         index = createIndex(page);
+    }
+
+    @Test
+    public void testOpenCloseOpen() throws Exception {
+        createPageFileAndIndex((short) 500);
+        reloadIndex();
+        doInsert(COUNT);
+        reloadAll();
+        checkRetrieve(COUNT);
     }
 
     @Test


### PR DESCRIPTION
Hi Hiram,

I've fixed an HashIndex bug causing java.lang.ArrayIndexOutOfBoundsException errors during index reopening: it was a bug related to headers read/write operations.
Everything works as expected, and I've also added a new test.

Can you push it into your repo and do a quick release?
Thanks!

Sergio B.
