### PR TITLE
Fixed HashIndex bugs affecting header read/write operations and capacity resize.

### DIFF
--- a/src/main/java/org/fusesource/hawtdb/internal/index/HashIndex.java
+++ b/src/main/java/org/fusesource/hawtdb/internal/index/HashIndex.java
@@ -16,15 +16,13 @@
  */
 package org.fusesource.hawtdb.internal.index;
 
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
 import org.fusesource.hawtbuf.Buffer;
-import org.fusesource.hawtbuf.DataByteArrayInputStream;
-import org.fusesource.hawtbuf.DataByteArrayOutputStream;
 import org.fusesource.hawtdb.api.*;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.HashSet;
-import java.util.List;
 import java.util.Map;
 
 import static org.fusesource.hawtdb.internal.index.Logging.debug;
@@ -279,9 +277,6 @@ public class HashIndex<Key,Value> implements Index<Key,Value> {
         
         public void destroy() {
             clear();
-            for (int i = 0; i < capacity; i++) {
-            index.paged.allocator().free(bucketsIndex[i], 1);
-            }
         }
         
         public void clear() {
@@ -315,13 +310,12 @@ public class HashIndex<Key,Value> implements Index<Key,Value> {
     public static final Buffer MAGIC = new Buffer(new byte[] {'h', 'a', 's', 'h'});
     public static final int HEADER_SIZE = MAGIC.length + 8; // capacity, active
 
-    private final PagedAccessor<Buckets<Key, Value>> BUCKET_PAGED_ACCESSOR = new PagedAccessor<Buckets<Key, Value>>() {
+    private final PagedAccessor<Buckets<Key, Value>> BUCKET_PAGED_ACCESSOR = new AbstractStreamPagedAccessor<Buckets<Key, Value>>() {
 
-        public List<Integer> store(Paged paged, int page, Buckets<Key, Value> buckets) {
-            DataByteArrayOutputStream os = new DataByteArrayOutputStream(HEADER_SIZE);
+        @Override
+        protected void encode(Paged paged, DataOutputStream os, Buckets<Key, Value> data) throws IOException {
             try {
-                Buffer magic2 = MAGIC;
-                os.write(magic2.data, MAGIC.offset, MAGIC.length);
+                os.write(MAGIC.data, MAGIC.offset, MAGIC.length);
                 os.writeInt(buckets.active);
                 os.writeInt(buckets.capacity);
                 for (int i =0; i < buckets.capacity; i++) {
@@ -330,40 +324,26 @@ public class HashIndex<Key,Value> implements Index<Key,Value> {
             } catch (IOException e) {
                 throw new IOPagingException(e);
             }
-            
-            Buffer buffer = os.toBuffer();
-            paged.write(page, buffer);
-            return Collections.emptyList();
         }
 
-        public Buckets<Key, Value> load(Paged paged, int page) {
+        @Override
+        protected Buckets<Key, Value> decode(Paged paged, DataInputStream is) throws IOException {
             Buckets<Key, Value> buckets = new Buckets<Key, Value>(HashIndex.this);
-            DataByteArrayInputStream is = null;
 
-            Buffer header = new Buffer(HEADER_SIZE);
-            paged.read(page, header);
-            is = new DataByteArrayInputStream(header);
             Buffer magic = new Buffer(MAGIC.length);
             is.readFully(magic.data, magic.offset, magic.length);
             if (!magic.equals(MAGIC)) {
-                throw new IndexException("Not a hash page");
+                throw new IOException("Not a hash page");
             }
             buckets.active = is.readInt();
             buckets.capacity = is.readInt();
 
-            Buffer indexes = new Buffer(HEADER_SIZE + (buckets.capacity * 4));
-            paged.read(page, indexes);
-            is = new DataByteArrayInputStream(indexes.offset(HEADER_SIZE));
             buckets.bucketsIndex = new int[buckets.capacity];
             for (int i =0; i < buckets.capacity; i++) {
                 buckets.bucketsIndex[i] = is.readInt();
             }
-            
+
             return buckets;
-        }
-        
-        public List<Integer> pagesLinked(Paged paged, int page) {
-            return Collections.emptyList();
         }
         
     };

--- a/src/test/java/org/fusesource/hawtdb/internal/index/HashIndexTest.java
+++ b/src/test/java/org/fusesource/hawtdb/internal/index/HashIndexTest.java
@@ -33,9 +33,7 @@ public class HashIndexTest extends IndexTestSupport {
         HashIndexFactory<String,Long> factory = new HashIndexFactory<String,Long>();
         factory.setKeyCodec(StringCodec.INSTANCE);
         factory.setValueCodec(LongCodec.INSTANCE);
-        factory.setBucketCapacity(1);
-        factory.setMinimumBucketCapacity(1);
-        factory.setMaximumBucketCapacity(1);
+        factory.setBucketCapacity(1024);
         if( page==-1 ) {
             return factory.create(tx);
         } else {


### PR DESCRIPTION
Hi Hiram,

I should have fixed all outstanding bugs regarding HashIndex: more specifically, I've changed HashIndex paged accessor to use AbstractStreamPagedAccessor, and I've fixed the buckets destroy method which was apparently freeing extra pages.
I changed tests to use dynamic capacity again, and all tests pass, please give it a look and let me know.

Thanks!
