### PR TITLE
Fixed subtle bug in snapshot management.

### DIFF
--- a/src/main/java/org/fusesource/hawtdb/internal/page/HawtTxPageFile.java
+++ b/src/main/java/org/fusesource/hawtdb/internal/page/HawtTxPageFile.java
@@ -258,7 +258,7 @@ public final class HawtTxPageFile implements TxPageFile {
     public ReadCache readCache() {
         return readCache;
     }
-    
+
     public void close() {
         if (worker != null) {
             final CountDownLatch done = new CountDownLatch(1);
@@ -857,7 +857,7 @@ public final class HawtTxPageFile implements TxPageFile {
             }
 
             // Open the snapshot
-            return new Snapshot(this, tracker, storedBatches).open();
+            return new Snapshot(this, tracker, storedBatches, openBatch).open();
         }
     }
 
@@ -893,4 +893,5 @@ public final class HawtTxPageFile implements TxPageFile {
         trace("storing file header: %s", header);
         file.write(0, header.encode());
     }
+
 }

--- a/src/main/java/org/fusesource/hawtdb/internal/page/Snapshot.java
+++ b/src/main/java/org/fusesource/hawtdb/internal/page/Snapshot.java
@@ -37,11 +37,13 @@ final class Snapshot {
     private final HawtTxPageFile parent;
     private final SnapshotTracker tracker;
     private final Batch base;
+    private final Batch latest;
     
-    public  Snapshot(HawtTxPageFile hawtPageFile, SnapshotTracker tracker, Batch base) {
+    public  Snapshot(HawtTxPageFile hawtPageFile, SnapshotTracker tracker, Batch base, Batch latest) {
         parent = hawtPageFile;
         this.tracker = tracker;
         this.base = base;
+        this.latest = latest;
     }
     
     public Snapshot open() {
@@ -49,10 +51,11 @@ final class Snapshot {
         Batch cur = base;
         while( true ) {
             cur.snapshots++;
-            if(cur == tracker.parentBatch) {
+            if(cur == latest) {
                 break;
             }
             cur = cur.getNext();
+            
         }
         return this;
     }
@@ -63,7 +66,7 @@ final class Snapshot {
             Batch cur = base;
             while( true ) {
                 cur.snapshots--;
-                if(cur == tracker.parentBatch) {
+                if(cur == latest) {
                     break;
                 }
                 cur = cur.getNext();

--- a/src/main/java/org/fusesource/hawtdb/internal/page/SnapshotTracker.java
+++ b/src/main/java/org/fusesource/hawtdb/internal/page/SnapshotTracker.java
@@ -33,6 +33,8 @@ final class SnapshotTracker {
     final Batch parentBatch;
     final Commit parentCommit;
     final long headRevision;
+    /** The number of times this snapshot has been opened. */
+    protected volatile int snapshots;
     
     public SnapshotTracker(Batch parentBatch, Commit parentCommit) {
         this.parentBatch = parentBatch;
@@ -40,9 +42,6 @@ final class SnapshotTracker {
         Commit lastEntry = this.parentBatch.commits.getTail();
         this.headRevision = (lastEntry == null ? this.parentBatch.head : lastEntry.getHeadRevision())+1;
     }
-
-    /** The number of times this snapshot has been opened. */
-    protected int snapshots;
     
     public String toString() { 
         return "{ references: "+this.snapshots+" }";


### PR DESCRIPTION
Hiram,

I fixed a subtle NPE happening sometimes during repeated IndexBenchmark tests.
It was apparently caused by a bug in the snapshot management: more specifically, the snapshot tracker which was reused in case of a previous open commit was pointing at a parent batch which was older than the current open batch, and so, given you used the parent batch as a bound for iterating through the batches, you ended up with NPE (because again, it was actually older than the latest open batch).
So I fixed it by explicitly passing the latest open batch to the new snapshot.
It will probably clearer by looking at my patch: if you think it is correct, please merge it prior to the release ... one more bug squashed :)

Keep me posted!
